### PR TITLE
Pipeline fix

### DIFF
--- a/frontend/entrypoint.sh
+++ b/frontend/entrypoint.sh
@@ -16,13 +16,21 @@ _term() {
 
 trap _term SIGTERM
 
+echo "Initialising common..."
+(cd ../common; npm install)
+
 echo "Replacing common symlink with directory..."
 rm -f src/common
 cp -r ../common src/common
 
-echo "Starting lsyncd..."
-lsyncd -nodaemon lsyncd.lua | sed -e 's/^/Lsyncd: /;' &
-LSYNCD=$!
+if command -v lsyncd &> /dev/null
+then
+    echo "Starting lsyncd..."
+    lsyncd -nodaemon lsyncd.lua | sed -e 's/^/Lsyncd: /;' &
+    LSYNCD=$!
+else
+    echo "Lsyncd not found, live syncing disabled" 1>&2
+fi 
 
 echo "Starting application..."
 "${@}" &


### PR DESCRIPTION
`/frontend/entrypoint.sh` now runs `npm install` in `/common` unconditionally. This adds 4 seconds on my machine to startup time in debug mode which isn't ideal but it'll do for now. I'd consider adding a post-checkout hook eventually to install dependencies in every subdirectory.